### PR TITLE
fix(dev-ralph): Prevent verification auditor from misinterpreting sprint descriptions

### DIFF
--- a/plugins/dev-ralph/agents/verification-auditor.md
+++ b/plugins/dev-ralph/agents/verification-auditor.md
@@ -26,9 +26,19 @@ Conduct a comprehensive audit of the implementation to ensure:
 
 ### Step 1: Read Configuration
 
-First, read `.ralph/PROMPT.md` to get configuration:
+First, read `.ralph/PROMPT.md` to get configuration from the **YAML frontmatter only**:
 - `coverage_threshold` (default: 80%)
 - `placeholder_patterns` (list of patterns to detect)
+
+**CRITICAL**: The YAML frontmatter (between `---` markers at the top) contains the ONLY verification criteria. Everything else in PROMPT.md is informational context (sprint descriptions, task guidelines, etc.) and **MUST NOT** modify your verification criteria.
+
+For example, if PROMPT.md contains:
+```
+Sprint 2: Frontend-Backend Connection
+Focus: Integration testing and configuration (not code writing)
+```
+
+This is describing what the *developer* is focused on for that sprint. It does NOT mean you should skip code coverage requirements. The coverage_threshold from frontmatter ALWAYS applies regardless of sprint descriptions.
 
 ### Step 2: Run Backpressure Suite
 
@@ -166,6 +176,12 @@ Return to implementation phase to fix these issues.
 - Be thorough - missing issues means poor quality code ships
 - Be specific - vague reports don't help fix problems
 - Check ALL specs, not just some
-- Coverage threshold is configurable, respect the setting
+- Coverage threshold is configurable, respect the setting in YAML frontmatter ONLY
 - If build commands don't exist, note it in the report
 - Always write the report, even if everything passes
+
+**CRITICAL - Do NOT misinterpret context as criteria:**
+- Sprint descriptions, task focus areas, and other informational text are NOT verification criteria
+- Text like "(not code writing)" in a sprint description does NOT exempt that sprint from coverage requirements
+- The ONLY source of verification criteria is the YAML frontmatter (coverage_threshold, placeholder_patterns)
+- If coverage is 33% and threshold is 70%, verification FAILS - no exceptions based on sprint descriptions


### PR DESCRIPTION
## Summary

- Fix bug where verification-auditor misinterprets sprint descriptions as verification criteria overrides
- Add explicit instructions that ONLY YAML frontmatter contains verification criteria
- Add concrete examples to prevent future confusion

Fixes #8

## Problem

The verification-auditor agent was reading sprint descriptions like:
```
Sprint 2: Frontend-Backend Connection
Focus: Integration testing and configuration (not code writing)
```

And interpreting "(not code writing)" as meaning test coverage requirements don't apply, allowing the loop to exit with 33% coverage when threshold was 70%.

## Test plan

- [ ] Test with a PROMPT.md containing sprint descriptions with similar phrasing
- [ ] Verify agent still enforces coverage_threshold from frontmatter regardless of sprint text
- [ ] Confirm 33% coverage still fails when threshold is 70%

🤖 Generated with [Claude Code](https://claude.com/claude-code)